### PR TITLE
Better handling of primitive projections

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -128,9 +128,10 @@ GENERATED+=.depend
 TESTDIR=tests
 TESTS_SRC=$(TESTDIR)/Morph.v $(TESTDIR)/Test.v $(TESTDIR)/Polymorph.v \
 	  $(TESTDIR)/Morph.cmd $(TESTDIR)/Test.cmd $(TESTDIR)/search.cmd \
-          $(TESTDIR)/Polymorph.cmd
+          $(TESTDIR)/Polymorph.cmd $(TESTDIR)/PrimitiveProjections.cmd
 TESTS_DPD=$(TESTDIR)/graph.dpd $(TESTDIR)/graph2.dpd \
-	  $(TESTDIR)/Morph.dpd $(TESTDIR)/Morph_rw.dpd $(TESTDIR)/Polymorph.dpd
+	  $(TESTDIR)/Morph.dpd $(TESTDIR)/Morph_rw.dpd $(TESTDIR)/Polymorph.dpd \
+          $(TESTDIR)/PrimitiveProjections.dpd $(TESTDIR)/PrimitiveProjections2.dpd
 TESTS_DOT=$(TESTS_DPD:%.dpd=%.dot)
 TESTS=$(TESTS_DPD) $(TESTS_DOT) $(TESTDIR)/graph.without.dot \
       $(TESTDIR)/search  $(TESTDIR)/graph2.dpdusage

--- a/dpd_compute.ml
+++ b/dpd_compute.ml
@@ -84,8 +84,7 @@ let build_graph lobj =
 
 
 
-(** remove edge (n1 -> n2) iff n2 is indirectly reachable by n1 *)
-(* TODO : not sure this is working for graphs with cycles *)
+(** remove edge (n1 -> n2) iff n2 is indirectly reachable by n1, or if n1 and n2 are the same *)
 let reduce_graph g =
   (* a table in which each node is mapped to the set of indirected accessible
    * nodes *)
@@ -98,7 +97,7 @@ let reduce_graph g =
       let add_succ_reachable acc s =
         let acc = (* add [s] successors *)
           List.fold_left (fun set x -> Vset.add x set) acc (G.succ g s)
-        in (Vset.union acc (reachable s))
+	in (Vset.union acc (if Node.equal v s then Vset.empty else reachable s))
       in
       let acc = List.fold_left add_succ_reachable Vset.empty (G.succ g v) in
         (* try to remove edges *)

--- a/tests/PrimitiveProjections.cmd
+++ b/tests/PrimitiveProjections.cmd
@@ -1,0 +1,8 @@
+Require Import dpdgraph.dpdgraph.
+
+Require PrimitiveProjections.
+Set DependGraph File "PrimitiveProjections.dpd".
+Print FileDependGraph PrimitiveProjections.
+Set DependGraph File "PrimitiveProjections2.dpd".
+
+Print DependGraph PrimitiveProjections.foo.

--- a/tests/PrimitiveProjections.dot.oracle
+++ b/tests/PrimitiveProjections.dot.oracle
@@ -1,0 +1,19 @@
+digraph G {
+  graph [ratio=0.5]
+  node [style=filled]
+PrimitiveProjections_foo [label="foo", URL=<PrimitiveProjections.html#foo>, peripheries=3, fillcolor="#F070D1"] ;
+PrimitiveProjections_baz [label="baz", URL=<PrimitiveProjections.html#baz>, peripheries=3, fillcolor="#F070D1"] ;
+PrimitiveProjections_bar [label="bar", URL=<PrimitiveProjections.html#bar>, peripheries=3, fillcolor="#F070D1"] ;
+PrimitiveProjections_projT2 [label="projT2", URL=<PrimitiveProjections.html#projT2>, peripheries=3, fillcolor="#F070D1"] ;
+PrimitiveProjections_projT1 [label="projT1", URL=<PrimitiveProjections.html#projT1>, fillcolor="#F070D1"] ;
+PrimitiveProjections_existT [label="existT", URL=<PrimitiveProjections.html#existT>, fillcolor="#7FAAFF"] ;
+PrimitiveProjections_sigT [label="sigT", URL=<PrimitiveProjections.html#sigT>, fillcolor="#E2CDFA"] ;
+  PrimitiveProjections_foo -> PrimitiveProjections_existT [] ;
+  PrimitiveProjections_foo -> PrimitiveProjections_sigT [] ;
+  PrimitiveProjections_baz -> PrimitiveProjections_sigT [] ;
+  PrimitiveProjections_bar -> PrimitiveProjections_projT1 [] ;
+  PrimitiveProjections_projT2 -> PrimitiveProjections_sigT [] ;
+  PrimitiveProjections_projT1 -> PrimitiveProjections_sigT [] ;
+subgraph cluster_PrimitiveProjections { label="PrimitiveProjections"; fillcolor="#FFFFC3"; labeljust=l; style=filled 
+PrimitiveProjections_sigT; PrimitiveProjections_existT; PrimitiveProjections_projT1; PrimitiveProjections_projT2; PrimitiveProjections_bar; PrimitiveProjections_baz; PrimitiveProjections_foo; };
+} /* END */

--- a/tests/PrimitiveProjections.dpd.oracle
+++ b/tests/PrimitiveProjections.dpd.oracle
@@ -1,0 +1,14 @@
+N: 5 "projT1" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+N: 2 "baz" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+N: 1 "foo" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+N: 7 "sigT" [kind=inductive, prop=no, path="PrimitiveProjections", ];
+N: 3 "bar" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+N: 6 "existT" [kind=construct, prop=no, path="PrimitiveProjections", ];
+N: 4 "projT2" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+E: 1 6 [weight=2, ];
+E: 1 7 [weight=8, ];
+E: 2 7 [weight=2, ];
+E: 3 5 [weight=1, ];
+E: 3 7 [weight=1, ];
+E: 4 7 [weight=2, ];
+E: 5 7 [weight=2, ];

--- a/tests/PrimitiveProjections.v
+++ b/tests/PrimitiveProjections.v
@@ -1,0 +1,17 @@
+Set Primitive Projections.
+Set Implicit Arguments.
+
+Record sigT {A} (P : A -> Type) := existT { projT1 : A ; projT2 : P projT1 }.
+
+Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
+
+Definition bar := @projT1.
+Definition baz A P (x : @sigT A P) := projT1 x.
+
+Definition foo (A: Type) (B: A -> Type) (C: A -> Type) (c: {x : A & {_ : B x & C x}}) : {x : A & {_ : C x & B x}}.
+Proof.
+  exists (projT1 c).
+  exists (projT2 (projT2 c)).
+  destruct c as [a [b c]].
+  exact b.
+Defined.

--- a/tests/PrimitiveProjections2.dot.oracle
+++ b/tests/PrimitiveProjections2.dot.oracle
@@ -1,0 +1,11 @@
+digraph G {
+  graph [ratio=0.5]
+  node [style=filled]
+PrimitiveProjections_foo [label="foo", URL=<PrimitiveProjections.html#foo>, peripheries=3, fillcolor="#F070D1"] ;
+PrimitiveProjections_sigT [label="sigT", URL=<PrimitiveProjections.html#sigT>, fillcolor="#E2CDFA"] ;
+PrimitiveProjections_existT [label="existT", URL=<PrimitiveProjections.html#existT>, fillcolor="#7FAAFF"] ;
+  PrimitiveProjections_foo -> PrimitiveProjections_sigT [] ;
+  PrimitiveProjections_foo -> PrimitiveProjections_existT [] ;
+subgraph cluster_PrimitiveProjections { label="PrimitiveProjections"; fillcolor="#FFFFC3"; labeljust=l; style=filled 
+PrimitiveProjections_existT; PrimitiveProjections_sigT; PrimitiveProjections_foo; };
+} /* END */

--- a/tests/PrimitiveProjections2.dpd.oracle
+++ b/tests/PrimitiveProjections2.dpd.oracle
@@ -1,0 +1,5 @@
+N: 8 "foo" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
+N: 9 "sigT" [kind=inductive, prop=no, path="PrimitiveProjections", ];
+N: 10 "existT" [kind=construct, prop=no, path="PrimitiveProjections", ];
+E: 8 9 [weight=8, ];
+E: 8 10 [weight=2, ];


### PR DESCRIPTION
Now dpdgraph with no longer stack overflow on primitive projections, which have self-edges.  However, there's still something strange going on; it seems that folded primitive projections don't get correctly recorded in the dependency graph in `collect_dependance`? 

![pp3](https://cloud.githubusercontent.com/assets/396076/22622996/7c4eba1a-eb19-11e6-96ac-95aa5a996bea.png)

Note how `baz` doesn't point to `projT1` despite being defined as 
```coq
Definition baz A P (x : @sigT A P) := projT1 x.
```

The dependency graph is
```
N: 5 "projT1" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
N: 2 "baz" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
N: 1 "foo" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
N: 7 "sigT" [kind=inductive, prop=no, path="PrimitiveProjections", ];
N: 3 "bar" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
N: 6 "existT" [kind=construct, prop=no, path="PrimitiveProjections", ];
N: 4 "projT2" [body=yes, kind=cnst, prop=no, path="PrimitiveProjections", ];
E: 1 6 [weight=2, ];
E: 1 7 [weight=8, ];
E: 2 7 [weight=2, ];
E: 3 5 [weight=1, ];
E: 3 7 [weight=1, ];
E: 4 7 [weight=2, ];
E: 5 7 [weight=2, ];
```

@mattam82 (or others), any ideas for what's going on?


Regardless, this change is still an improvement over the existing behavior with primitive projections.

Let me know if you want me to drop the whitespace change commits.