### PR TITLE
Display differences in travis log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ script:
 - ./configure
 - make
 - make tests | tee tmp.log
+- if grep DIFFERENCES tmp.log ; then for i in $(grep DIFFERENCES tmp.log | grep -o 'diff .*' | sed s'/diff //g' | sed s'/ /~/g'); do i="$(echo "$i" | sed s'/~/ /g')"; echo diff $i; diff $i; done ; fi
 - if grep DIFFERENCES tmp.log ; then exit 1 ; else exit 0 ; fi


### PR DESCRIPTION
This way, if travis fails, we can more easily see what went wrong.