### PR TITLE
Clobber attributes.err file

### DIFF
--- a/tests/attributes.err.oracle
+++ b/tests/attributes.err.oracle
@@ -1,2 +1,2 @@
 Info: read file tests/attributes.err.dpd
-Error: parsing error (line:3, character:25-26).
+Error: no node with number 10: cannot build edge.


### PR DESCRIPTION
It is not tested on travis (see #21).  This diff lines up with the one on travis.