### PR TITLE
Avoid race condition when building with -j2

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ VERSION=@PACKAGE_VERSION@
 
 BINDIR=@BINDIR@
 
-DPDPLUGIN=./dpdgraph.cmxs ./dpdgraph.vo
+DPDPLUGIN=./dpdgraph.vo
 DPD2DOT=./dpd2dot
 DPDUSAGE=./dpdusage
 


### PR DESCRIPTION
The `.vo` file depends on the `cmxs`, so there is really no need to build both (in parallel or not)