### PR TITLE
escape names 'graph' and 'digraph' to avoid bugs with graph viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Usage : ./dpd2dot [options]
   -help  Display this list of options
   --help  Display this list of options
 ```
+If the name of the output file finishes with ``.dot``, then the name before
+the ``.dot`` suffix is used as the graph name in the dot syntax.  There
+are two exceptions: ``graph`` and ``digraph`` will be replaced with
+``escaped_graph`` and ``escaped_digraph`` respectively.
 
 The only useful option at the moment is ``-without-defs`` that export only
 ``Prop`` objects to the graph (``Axiom``, ``Theorem``, ``Lemma``, etc).

--- a/dpd_dot.ml
+++ b/dpd_dot.ml
@@ -166,7 +166,13 @@ let print_graph name fmt graph =
       (node_dot_id (G.E.src e)) (node_dot_id (G.E.dst e))
       (print_attribs ", ") edge_attribs
   in
-  Format.fprintf fmt "digraph %s {@." name;
+  let escaped_name =
+    if (String.compare name "graph" = 0) ||
+       (String.compare name "digraph" = 0) then
+      String.concat "" ["escaped_"; name]
+    else
+      name in
+  Format.fprintf fmt "digraph %s {@." escaped_name;
   Format.fprintf fmt "  graph [ratio=0.5]@.";
   Format.fprintf fmt "  node [style=filled]@.";
   G.iter_vertex print_node graph;


### PR DESCRIPTION
The graph in file f.dot used to be named G whatever the name of the file.
@JasonGross suggested that the graph name should be taken from the output file name (PR #12)
However I discovered that names graph and digraph provoke errors with several
graph viewers (xdot, kgraphviewer).