### PR TITLE
Change Arguments Scope to Arguments

### DIFF
--- a/tests/Test.v
+++ b/tests/Test.v
@@ -92,7 +92,7 @@ Delimit Scope list_scope with list.
 
 Bind Scope list_scope with list.
 
-Arguments Scope list [type_scope].
+Arguments list _%type_scope.
 
 (** ** Facts about lists *)
 


### PR DESCRIPTION
The Arguments Scope command is deprecated. See also coq/coq#6802.
It's been producing a warning in Travis as well, ex. https://travis-ci.org/Karmaki/coq-dpdgraph/jobs/324485855#L817