### PR TITLE
Deprecation removal may 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - opam config var root
 - opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || true
 - opam install -y ocamlfind ocamlgraph
-- travis_wait opam install -y coq.8.8.dev
+- travis_wait opam install -y coq.dev
 - opam list
 script:
 - autoconf

--- a/graphdepend.ml4
+++ b/graphdepend.ml4
@@ -48,7 +48,7 @@ with _ ->
 module G = struct
 
   module Node = struct
-    type t = int * Globnames.global_reference
+    type t = int * Names.GlobRef.t
     let id n = fst n
     let gref n = snd n
     let compare n1 n2 = Pervasives.compare (id n1) (id n2)
@@ -88,7 +88,7 @@ module G = struct
 
   module Edges = Set.Make (Edge)
 
-  type t = (Globnames.global_reference, int) Hashtbl.t * Edges.t
+  type t = (Names.GlobRef.t, int) Hashtbl.t * Edges.t
 
   let empty () = Hashtbl.create 10, Edges.empty
 

--- a/searchdepend.ml4
+++ b/searchdepend.ml4
@@ -66,7 +66,7 @@ let collect_long_names (c:Constr.t) (acc:Data.t) =
           add c acc
   in add c acc
 
-exception NoDef of Globnames.global_reference
+exception NoDef of Names.GlobRef.t
 
 let collect_dependance gref =
   match gref with


### PR DESCRIPTION
adapt the travis configuration to run on the master branch of coq.
modify the sources to conform to deprecation warnings.