### PR TITLE
Tweak a let open to support old camlp5

### DIFF
--- a/graphdepend.ml4
+++ b/graphdepend.ml4
@@ -34,7 +34,7 @@ let get_dirlist_grefs dirlist =
 
 let is_prop gref id =
 try
-  let t, ctx = Universes.type_of_global gref in
+  let t, ctx = UnivGen.type_of_global gref in
   let env = Environ.push_context_set ctx (Global.env ()) in
   let s = (Typeops.infer_type env t).Environ.utj_type in
   Sorts.is_prop s

--- a/searchdepend.ml4
+++ b/searchdepend.ml4
@@ -71,7 +71,8 @@ exception NoDef of Names.GlobRef.t
 
 let collect_dependance gref =
   (* This will change to Names.GlobRef in 8.10 *)
-  let open Names.GlobRef in
+  let open Names in
+  let open GlobRef in
   match gref with
   | VarRef _ -> assert false
   | ConstRef cst ->


### PR DESCRIPTION
It turns out that older versions of camlp5 don't like a composed
module name in a `let open`, we thus tweak it to make Coq's CI to
pass.

As this branch tracks coq-master we also remove a new warning while
we are at it.