### PR TITLE
check stability of coq implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 - opam config var root
 - opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || true
 - opam install -y ocamlfind ocamlgraph
+- git clone --depth=1 https://github.com/coq/coq
+- if [ $(opam show --field=source-hash coq) = $(set -e 's/\(.\{8\}\).(/\1/' coq/.git/refs/heads/master) ] ; then true ; else opam uninstall coq ; fi ; rm -rf coq
 - travis_wait opam install -y coq.dev
 - opam list
 script:


### PR DESCRIPTION
The travis scripts caches the compiled version of coq.  This is nice when there are many commits
to coq-dpdgraph in a row, ensuring that tests performed by travis are very short.

However, for changes that are done to follow changes of api in Coq, this fails, because the new version of coq-dpdgraph is then compiled against the old version of coq that remained in the cache.

This modification checks the equality between short hash keys of the cached compiled version of coq and the short hash key at the tip of the master branch in the coq repository, in case of a
mismatch, it forces the old version of coq to be removed.