### PR TITLE
[coq] Fix OCaml warnings.

### DIFF
--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -90,7 +90,7 @@ module G = struct
 
   module Edges = Set.Make (Edge)
 
-  module GMap = Map.Make (Globnames.RefOrdered_env)
+  module GMap = Map.Make (Names.GlobRef.Ordered_env)
 
   type t = int GMap.t * Edges.t
 
@@ -187,6 +187,7 @@ end = struct
     let acc = match cb.Declarations.const_body with
       | Declarations.OpaqueDef _
       | Declarations.Def _ -> ("body", "yes")::acc
+      | Declarations.Primitive _
       | Declarations.Undef _  -> ("body", "no")::acc
     in acc
 

--- a/searchdepend.mlg
+++ b/searchdepend.mlg
@@ -14,16 +14,16 @@ open Pp
 open Stdarg
 
 module Data = struct
-  type t = int Globnames.Refmap.t
+  type t = int Names.GlobRef.Map.t
 
-  let empty = Globnames.Refmap.empty
+  let empty = Names.GlobRef.Map.empty
 
   let add gref d =
-    let n = try  Globnames.Refmap.find gref d with Not_found -> 0 in
-    Globnames.Refmap.add gref (n+1) d
+    let n = try  Names.GlobRef.Map.find gref d with Not_found -> 0 in
+    Names.GlobRef.Map.add gref (n+1) d
 
       (* [f gref n acc] *)
-  let fold f d acc = Globnames.Refmap.fold f d acc
+  let fold f d acc = Names.GlobRef.Map.fold f d acc
 end
 
 let add_identifier (x:Names.Id.t)(d:Data.t) =
@@ -67,6 +67,7 @@ let collect_long_names (c:Constr.t) (acc:Data.t) =
           Array.fold_right add ca (Array.fold_right add ca' acc)
       | Proj(p, c) ->
           add c acc
+      | Int _ -> acc
   in add c acc
 
 exception NoDef of Names.GlobRef.t


### PR DESCRIPTION
In anticipation to https://github.com/coq/coq/pull/9605 , we fix all
OCaml warnings.

Note that 2 warnings here [missing constructor] are serious bugs (cc:
@maximedenes as to illustrate the common problem we are seeing)

Fixes #57