### PR TITLE
fixes warnings about non-exhaustivepattern-matching and some deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - sudo apt-get install -qq -y opam
 - opam --version
 - opam init -y
-- opam switch 4.07.0
+- opam switch create 4.07.0
 - eval $(opam config env)
 - opam config var root
 - opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || true

--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -90,7 +90,7 @@ module G = struct
 
   module Edges = Set.Make (Edge)
 
-  module GMap = Map.Make (Globnames.RefOrdered_env)
+  module GMap = Map.Make (Names.GlobRef.Ordered_env)
 
   type t = int GMap.t * Edges.t
 
@@ -188,6 +188,7 @@ end = struct
       | Declarations.OpaqueDef _
       | Declarations.Def _ -> ("body", "yes")::acc
       | Declarations.Undef _  -> ("body", "no")::acc
+      | Declarations.Primitive _ -> ("body", "no")::acc
     in acc
 
   let add_gref_attrib acc gref id =

--- a/searchdepend.mlg
+++ b/searchdepend.mlg
@@ -14,16 +14,16 @@ open Pp
 open Stdarg
 
 module Data = struct
-  type t = int Globnames.Refmap.t
+  type t = int Names.GlobRef.Map.t
 
-  let empty = Globnames.Refmap.empty
+  let empty = Names.GlobRef.Map.empty
 
   let add gref d =
-    let n = try  Globnames.Refmap.find gref d with Not_found -> 0 in
-    Globnames.Refmap.add gref (n+1) d
+    let n = try  Names.GlobRef.Map.find gref d with Not_found -> 0 in
+    Names.GlobRef.Map.add gref (n+1) d
 
       (* [f gref n acc] *)
-  let fold f d acc = Globnames.Refmap.fold f d acc
+  let fold f d acc = Names.GlobRef.Map.fold f d acc
 end
 
 let add_identifier (x:Names.Id.t)(d:Data.t) =
@@ -47,6 +47,7 @@ let collect_long_names (c:Constr.t) (acc:Data.t) =
     let open Constr in
     match kind c with
         Rel _ -> acc
+      | Int _ -> acc
       | Var x -> add_identifier x acc
       | Meta _ -> assert false
       | Evar _ -> assert false


### PR DESCRIPTION
but there is a problem with 'UnivGen.type_of_global' that has no clear
replacement