### PR TITLE
fix deprecation warning for UnivGen.type_of_global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - sudo apt-get install -qq -y opam
 - opam --version
 - opam init -y
-- opam switch create 4.07.0
+- opam switch 4.07.0 || opam switch create 4.07.0
 - eval $(opam config env)
 - opam config var root
 - opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || true

--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -37,6 +37,8 @@ let get_dirlist_grefs dirlist =
 let is_prop gref id =
 try
   let t, ctx = Typeops.type_of_global_in_context (Global.env()) gref in
+(* Beware of this code, not considered entirely correct, but I don't know
+   how to fix it. *)
   let env = Environ.push_context ~strict:false (Univ.AUContext.repr ctx)
             (Global.env ()) in
   let s = (Typeops.infer_type env t).Environ.utj_type in

--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -36,8 +36,9 @@ let get_dirlist_grefs dirlist =
 
 let is_prop gref id =
 try
-  let t, ctx = UnivGen.type_of_global gref in
-  let env = Environ.push_context_set ctx (Global.env ()) in
+  let t, ctx = Typeops.type_of_global_in_context (Global.env()) gref in
+  let env = Environ.push_context ~strict:false (Univ.AUContext.repr ctx)
+            (Global.env ()) in
   let s = (Typeops.infer_type env t).Environ.utj_type in
   Sorts.is_prop s
 with _ ->


### PR DESCRIPTION
From comments gathered in gitter, this is not the recommended way to type the type of an expression, but in this case, this is not too serious, because the environment is only used for a simple operation
and the fact that it is corrupted (with Var universes) will not have an impact.