### PR TITLE
No kill on warning

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -49,7 +49,8 @@ OCAMLDEP=@OCAMLDEP@
 OCAMLLEX=@OCAMLLEX@
 OCAMLYACC=@OCAMLYACC@
 
-OCAMLFLAGS :=  -w +a -warn-error +a -g -dtypes $(INCLUDES) -c
+WARN_ERR := -warn-error +a
+OCAMLFLAGS :=  -w +a $(WARN_ERR) -g -dtypes $(INCLUDES) -c
 OCAMLFLAGS += $(OCAML_EXTRA_OPTS)
 OCAMLOPTFLAGS = -c
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ You can:
 
 #### Requirements
 
-- The latest version runs with Coq 8.7.0
+- The latest version runs with Coq 8.10.0
 - it has been tested with a version of Coq installed using opam and with
-  Ocaml version 4.04.2
+  Ocaml version 4.09.0
 - [ocamlgraph](http://ocamlgraph.lri.fr/) (for dpd2dot tool)
   Any version should work since only the basic feature are used.
 
@@ -63,6 +63,15 @@ Depending on how you got hold of the archive, you may be in one of three situati
 
     $ autoconf
     $ configure && make && make install
+
+#### lenient compilation
+
+   By default, compilation will fail if there is any warning emitted by
+   the ocaml compiler.  This can be disabled by type
+
+      make WARN_ERR=
+
+   instead of `make` in all previous commands.
 
 #### install using opam
 

--- a/configure.ac
+++ b/configure.ac
@@ -184,8 +184,8 @@ COQVERSION=$($COQC -v | sed -n -e 's|.*version *\(.*\)$|\1|p' )
 AC_MSG_RESULT($COQVERSION)
 
 case $COQVERSION in
-  8.1[^0-9]*|8.2[0-9]*|8.3[0-9]*|8.4[0-9]*|8.5[0-9]*|8.6[0-9]*|8.7[0-9]*)
-    AC_MSG_ERROR(AC_PACKAGE_NAME needs Coq version 8.8 or higher)
+  8.[[0-9]][[^0-9]]*|8.10*)
+    AC_MSG_ERROR(AC_PACKAGE_NAME needs Coq version 8.11 or higher)
     ;;
 esac
 


### PR DESCRIPTION
This branch proposes two modification

  - the verification of coq version in the configure file had to be updated because we are now moving in versions higher than 8.10, and there was a misleading error on previous version checking
  - the makefile is strict about not accepting warnings during compilation, but if we wish the compilation by final users to be robust with respect to the version of OCaml they are using, then we should not be so strict.  At least opam packaging should have the option to use a lenient compilation with respect to warnings.  This is obtained by a small change to the makefile, which is also documented in the README.md file.