### PR TITLE
Revert "Adapt w.r.t. coq/coq#13075."

### DIFF
--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -93,7 +93,7 @@ module G = struct
 
   module Edges = Set.Make (Edge)
 
-  module GMap = Names.GlobRef.Map_env
+  module GMap = Map.Make (Names.GlobRef.Ordered_env)
 
   type t = int GMap.t * Edges.t
 


### PR DESCRIPTION
Reverts Karmaki/coq-dpdgraph#74.

The above PR changes the order of the nodes generated for the graph, so the tests actually fail on the CI. Instead of trying to get backwards compat in a kludgy way, I'll write a non-compatible source code overlay for coq/coq#13075. In the meantime by merging this the PR will be reverted.