### PR TITLE
Adapt to Coq PR #14846: references to inductive types in the type of constructors are directly Ind rather than Rel nodes

### DIFF
--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -39,7 +39,7 @@ try
   let t, ctx = Typeops.type_of_global_in_context (Global.env()) gref in
 (* Beware of this code, not considered entirely correct, but I don't know
    how to fix it. *)
-  let env = Environ.push_context ~strict:false (Univ.AUContext.repr ctx)
+  let env = Environ.push_context ~strict:false (Univ.AbstractContext.repr ctx)
             (Global.env ()) in
   let s = (Typeops.infer_type env t).Environ.utj_type in
   Sorts.is_prop s

--- a/searchdepend.mlg
+++ b/searchdepend.mlg
@@ -42,15 +42,15 @@ let add_inductive ((k,i):Names.inductive)(d:Data.t) =
 let add_constructor(((k,i),j):Names.constructor)(d:Data.t) =
   Data.add (Names.GlobRef.ConstructRef ((k,i),j)) d
 
-let collect_long_names (c:Constr.t) (acc:Data.t) =
+let collect_long_names avoid (c:Constr.t) (acc:Data.t) =
   let rec add acc c =
     let open Constr in
     match kind c with
       | Var x -> add_identifier x acc
       | Sort s -> add_sort s acc
       | Const cst -> add_constant (Univ.out_punivs cst) acc
-      | Ind i -> add_inductive (Univ.out_punivs i) acc
-      | Construct cnst -> add_constructor (Univ.out_punivs cnst) acc
+      | Ind (i,_) when not (List.exists (Names.MutInd.CanOrd.equal (fst i)) avoid) -> add_inductive i acc
+      | Construct (cnst,_) when not (List.exists (Names.MutInd.CanOrd.equal (fst (fst cnst))) avoid) -> add_constructor cnst acc
       | Case({ci_ind=i},_,_,_,_,_,_) ->
           add_inductive i (Constr.fold add acc c)
       | _ -> Constr.fold add acc c
@@ -70,11 +70,11 @@ let collect_dependance gref =
          Some (e,_,_) -> [e]
 	| None -> [] in
       let cl = cb.Declarations.const_type :: cl in
-      List.fold_right collect_long_names cl Data.empty
+      List.fold_right (collect_long_names []) cl Data.empty
   | IndRef i | ConstructRef (i,_) ->
       let _, indbody = Global.lookup_inductive i in
       let ca = indbody.Declarations.mind_user_lc in
-        Array.fold_right collect_long_names ca Data.empty
+        Array.fold_right (collect_long_names [fst i]) ca Data.empty
 
 let display_dependance gref =
   let display d =


### PR DESCRIPTION
As a consequence, while building the dependency graph, we have to take into account that the type of a constructor now recursively refers to inductive types of the same block.

This is to be merged synchronously with coq/coq#14846. Thanks in advance.