### PR TITLE
Ignore warning 70

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ OCAMLLEX=@OCAMLLEX@
 OCAMLYACC=@OCAMLYACC@
 
 WARN_ERR := -warn-error +a
-OCAMLFLAGS :=  -w +a $(WARN_ERR) -g -dtypes $(INCLUDES) -c
+OCAMLFLAGS :=  -w +a $(WARN_ERR) -g -dtypes $(INCLUDES) -c -w -70
 OCAMLFLAGS += $(OCAML_EXTRA_OPTS)
 OCAMLOPTFLAGS = -c
 


### PR DESCRIPTION
We ignore the warning about missing .mli files.

This allows for compilation on OCaml 4.13.

I tried adding a few mli files however it is not obvious to me how to do this.