### PR TITLE
Adapt to Coq PR #17987 which adds sigma to the API of search functions

### DIFF
--- a/graphdepend.mlg
+++ b/graphdepend.mlg
@@ -26,12 +26,12 @@ let filename = ref "graph.dpd"
 
 let get_dirlist_grefs dirlist =
   let selected_gref = ref [] in
-  let select gref kind env constr =
-    if Search.module_filter (SearchInside dirlist) gref kind env (Evd.from_env env) constr then
+  let select gref kind env sigma constr =
+    if Search.module_filter (SearchInside dirlist) gref kind env sigma constr then
     (debug (str "Select " ++ Printer.pr_global gref);
      selected_gref := gref::!selected_gref)
   in
-    Search.generic_search (Global.env()) select;
+    Search.generic_search (Global.env()) (Evd.from_env (Global.env())) select;
     !selected_gref
 
 let is_prop gref id =


### PR DESCRIPTION
The Coq PR is to fix #17963: sigma has to be passed to search functions.

It has to be merged synchronously with coq/coq#17987.

Note: the call to `Global.env()` could also be factorized if you wish.