### PR TITLE
force sequential execution

### DIFF
--- a/Make_coq.local
+++ b/Make_coq.local
@@ -1,3 +1,5 @@
+.NOTPARALLEL:
+
 DPD2DOT=./dpd2dot
 DPDUSAGE=./dpdusage
 ML_COMMON = version.ml dpd_compute.ml dpd_dot.ml \


### PR DESCRIPTION
The makefile, inherited from years ago, relies on ocamlfind to generate some of the files.  However, this command generates several files at a time, and these files are actually generated twice for two different assets.  If one uses parallel compilation, this results in corruption.

The code in this package is very small and the time to compile and test is so short that we can afford avoiding parallel computation.

