### PR TITLE
Keep the dependencies between members of a mutual inductive block

### DIFF
--- a/Make_coq.local
+++ b/Make_coq.local
@@ -52,16 +52,18 @@ uninstall ::
 
 TESTDIR=tests
 TESTS_SRC=$(TESTDIR)/Morph.v $(TESTDIR)/Test.v $(TESTDIR)/Polymorph.v \
-	  $(TESTDIR)/PrimitiveProjections.v\
+	  $(TESTDIR)/PrimitiveProjections.v $(TESTDIR)/MutualInductive.v\
 	  $(TESTDIR)/Morph.cmd $(TESTDIR)/Test.cmd $(TESTDIR)/search.cmd \
-          $(TESTDIR)/Polymorph.cmd $(TESTDIR)/PrimitiveProjections.cmd
+          $(TESTDIR)/Polymorph.cmd $(TESTDIR)/PrimitiveProjections.cmd \
+          $(TESTDIR)/MutualInductive.cmd
 TESTS_DPD=$(TESTDIR)/graph.dpd $(TESTDIR)/graph2.dpd \
 	  $(TESTDIR)/Morph.dpd $(TESTDIR)/Morph_rw.dpd \
 	  $(TESTDIR)/Polymorph.dpd \
           $(TESTDIR)/PrimitiveProjections.dpd \
-	  $(TESTDIR)/PrimitiveProjections2.dpd
+	  $(TESTDIR)/PrimitiveProjections2.dpd \
+	  $(TESTDIR)/MutualInductive.dpd
 TESTS_VO=$(TESTDIR)/Morph.vo $(TESTDIR)/Test.vo $(TESTDIR)/Polymorph.vo\
-         $(TESTDIR)/PrimitiveProjections.vo
+         $(TESTDIR)/PrimitiveProjections.vo $(TESTDIR)/MutualInductive.vo
 TESTS_DOT=$(TESTS_DPD:%.dpd=%.dot)
 TESTS_ERR_DPD=$(wildcard $(TESTDIR)/*.err.dpd)
 
@@ -78,6 +80,7 @@ clean_test :
 	rm -f $(TESTDIR)/Morph.vo $(TESTDIR)/Morph.glob
 	rm -f $(TESTDIR)/Polymorph.vo $(TESTDIR)/Polymorph.glob
 	rm -f $(TESTDIR)/PrimitiveProjections.vo $(TESTDIR)/PrimitiveProjections.glob
+	rm -f $(TESTDIR)/MutualInductive.vo $(TESTDIR)/MutualInductive.glob
 	rm -f  $(TESTDIR)/.*.vo.aux
 
 .PRECIOUS : $(TESTS) $(TESTS_LOG) $(TESTS_ORACLE)

--- a/dpd_compute.ml
+++ b/dpd_compute.ml
@@ -130,32 +130,62 @@ let build_graph lobj =
 
 
 (** remove edge (n1 -> n2) iff n2 is indirectly reachable by n1,
- * or if n1 and n2 are the same *)
+ * or if n1 and n2 are the same.
+ *
+ * The graph can have cycles: the members of a mutual inductive block refer to
+ * each other.  So both the reachability and the "is this edge redundant" test
+ * are computed on the strongly connected components, over the acyclic graph
+ * they form, rather than by recursing along the edges of each node -- that
+ * recursion does not terminate on a cycle, and asking whether n2 is reachable
+ * from n1 in two steps or more would answer yes for every edge entering a
+ * cycle, leaving the node it comes from isolated.
+ *
+ * Edges between two distinct nodes of the same component are kept: each of
+ * them is redundant in the above sense, so removing them would drop the cycle
+ * from the graph altogether. *)
 let reduce_graph g =
-  (* a table in which each node is mapped to the set of indirected accessible
-   * nodes *)
-  let module Vset = Set.Make (G.V) in
-  let reach_tbl = Hashtbl.create (G.nb_vertex g) in
-  let rec reachable v =
-    try Hashtbl.find reach_tbl v (* already done *)
-    with Not_found ->
-      let nb_succ_before = List.length (G.succ g v) in
-      let add_succ_reachable acc s =
-        let acc = (* add [s] successors *)
-          List.fold_left (fun set x -> Vset.add x set) acc (G.succ g s)
-	in (Vset.union acc (if Node.equal v s then Vset.empty else reachable s))
-      in
-      let acc = List.fold_left add_succ_reachable Vset.empty (G.succ g v) in
-        (* try to remove edges *)
-      let rm_edge sv = if Vset.mem sv acc then G.remove_edge g v sv in
-      List.iter rm_edge (G.succ g v);
-      let nb_succ_after = List.length (G.succ g v) in
-      debug "Reduce for %s : %d -> %d@." (Node.name v)
-        nb_succ_before nb_succ_after;
-      Hashtbl.add reach_tbl v acc;
-      acc
+  (* a table in which each component is mapped to the set of components
+   * indirectly accessible from it *)
+  let module Cset = Set.Make (Int) in
+  let module Scc = Graph.Components.Make (G) in
+  let nb_scc, scc_of = Scc.scc g in
+  let succs = Array.make nb_scc [] in
+  G.iter_vertex
+    (fun v -> let c = scc_of v in succs.(c) <- G.succ g v @ succs.(c)) g;
+  let reach_tbl = Array.make nb_scc None in
+  let rec reachable c = match reach_tbl.(c) with
+    | Some set -> set (* already done *)
+    | None ->
+        let add set s =
+          let cs = scc_of s in
+          (* the components below [c] are reached through the successors of
+           * [c]'s own members, which are all in [succs.(c)] already *)
+          if cs = c then set
+          else Cset.union (Cset.add cs set) (reachable cs)
+        in
+        let set = List.fold_left add Cset.empty succs.(c) in
+          reach_tbl.(c) <- Some set;
+          set
   in
-    G.iter_vertex (fun v -> ignore (reachable v)) g
+  let reduce v =
+    let c = scc_of v in
+    let nb_succ_before = List.length (G.succ g v) in
+    (* the components reachable from [v] in two steps or more *)
+    let acc =
+      List.fold_left (fun acc s -> Cset.union acc (reachable (scc_of s)))
+        Cset.empty (G.succ g v)
+    in
+    let rm_edge sv =
+      let cs = scc_of sv in
+      if Node.equal v sv || (cs <> c && Cset.mem cs acc) then
+        G.remove_edge g v sv
+    in
+    List.iter rm_edge (G.succ g v);
+    let nb_succ_after = List.length (G.succ g v) in
+    debug "Reduce for %s : %d -> %d@." (Node.name v)
+      nb_succ_before nb_succ_after
+  in
+    G.iter_vertex reduce g
 
 let remove_node g n =
   let transfer_edges p =

--- a/searchdepend.mlg
+++ b/searchdepend.mlg
@@ -60,8 +60,8 @@ let collect_long_names avoid (c:Constr.t) (acc:Data.t) =
       | Var x -> add_identifier x acc
       | Sort s -> add_sort s acc
       | Const cst -> add_constant (UVars.out_punivs cst) acc
-      | Ind (i,_) when not (List.exists (Names.MutInd.CanOrd.equal (fst i)) avoid) -> add_inductive i acc
-      | Construct (cnst,_) when not (List.exists (Names.MutInd.CanOrd.equal (fst (fst cnst))) avoid) -> add_constructor cnst acc
+      | Ind (i,_) when not (List.exists (Names.Ind.CanOrd.equal i) avoid) -> add_inductive i acc
+      | Construct (cnst,_) when not (List.exists (Names.Ind.CanOrd.equal (fst cnst)) avoid) -> add_constructor cnst acc
       | Case({ci_ind=i},_,_,_,_,_,_) ->
           add_inductive i (Constr.fold add acc c)
       | _ -> Constr.fold add acc c
@@ -90,7 +90,7 @@ let collect_dependance opaque_access gref =
   | IndRef i | ConstructRef (i,_) ->
       let _, indbody = Global.lookup_inductive i in
       let ca = indbody.Declarations.mind_user_lc in
-        Array.fold_right (collect_long_names [fst i]) ca Data.empty
+        Array.fold_right (collect_long_names [i]) ca Data.empty
 
 let display_dependance ~opaque_access gref =
   let display d =

--- a/tests/MutualInductive.cmd
+++ b/tests/MutualInductive.cmd
@@ -1,0 +1,6 @@
+Require Import dpdgraph.dpdgraph.
+
+Require MutualInductive.
+Set DependGraph File "MutualInductive.dpd".
+
+Print FileDependGraph MutualInductive.

--- a/tests/MutualInductive.dot.oracle
+++ b/tests/MutualInductive.dot.oracle
@@ -1,0 +1,14 @@
+digraph tests/MutualInductive {
+  graph [ratio=0.5]
+  node [style=filled]
+MutualInductive_RecV [label="RecV", URL=<MutualInductive.html#RecV>, peripheries=3, fillcolor="#7FAAFF"] ;
+MutualInductive_val [label="val", URL=<MutualInductive.html#val>, fillcolor="#E2CDFA"] ;
+MutualInductive_OfVal [label="OfVal", URL=<MutualInductive.html#OfVal>, peripheries=3, fillcolor="#7FAAFF"] ;
+MutualInductive_expr [label="expr", URL=<MutualInductive.html#expr>, fillcolor="#E2CDFA"] ;
+  MutualInductive_RecV -> MutualInductive_expr [] ;
+  MutualInductive_val -> MutualInductive_expr [] ;
+  MutualInductive_OfVal -> MutualInductive_val [] ;
+  MutualInductive_expr -> MutualInductive_val [] ;
+subgraph cluster_MutualInductive { label="MutualInductive"; fillcolor="#FFFFC3"; labeljust=l; style=filled 
+MutualInductive_expr; MutualInductive_OfVal; MutualInductive_val; MutualInductive_RecV; };
+} /* END */

--- a/tests/MutualInductive.dpd.oracle
+++ b/tests/MutualInductive.dpd.oracle
@@ -1,0 +1,8 @@
+N: 4 "expr" [kind=inductive, prop=no, path="MutualInductive", ];
+N: 2 "val" [kind=inductive, prop=no, path="MutualInductive", ];
+N: 3 "OfVal" [kind=construct, prop=no, path="MutualInductive", ];
+N: 1 "RecV" [kind=construct, prop=no, path="MutualInductive", ];
+E: 1 4 [weight=1, ];
+E: 2 4 [weight=1, ];
+E: 3 2 [weight=1, ];
+E: 4 2 [weight=1, ];

--- a/tests/MutualInductive.v
+++ b/tests/MutualInductive.v
@@ -1,0 +1,10 @@
+(* Each member of a mutual inductive block refers to its siblings, so the
+   dependency graph must contain those edges.  Elimination schemes are off so
+   the graph is just the block itself. *)
+
+Unset Elimination Schemes.
+
+Inductive expr : Type :=
+  | OfVal : val -> expr
+with val : Type :=
+  | RecV : expr -> val.


### PR DESCRIPTION
- `collect_dependance` avoids a whole `MutInd` when walking constructor types, so it drops the edges *between* members of a mutual inductive block, not just the self-reference it means to suppress. `Inductive expr := OfVal (v : val) with val := RecV (e : expr)` yields four nodes and no edges at all. First commit: avoid the inductive being processed instead.
- That makes cycles reachable for the first time — nothing else in a dpd graph produces one — and `dpd2dot` stack-overflows on any cycle. Second commit: compute `reduce_graph`'s reachability over strongly connected components. Identical results on acyclic graphs; every pre-existing oracle unchanged.
- New `tests/MutualInductive` case. `make test` passes, 26 tests, against Rocq dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gna9AxbEH5BjMv5V4Q97n
